### PR TITLE
replace httr::GET() with httr::RETRY()

### DIFF
--- a/R/AAA-getDataCM.R
+++ b/R/AAA-getDataCM.R
@@ -31,7 +31,7 @@
 #' }
 #' 
 #' @seealso ClimMob website \url{https://climmob.net/}
-#' @importFrom httr accept_json content GET
+#' @importFrom httr accept_json content RETRY
 #' @importFrom jsonlite fromJSON
 #' @importFrom tibble as_tibble
 #' @export
@@ -41,10 +41,12 @@ getDataCM <- function(key = NULL,
   
   url <- "https://climmob.net/climmob3/api/readDataOfProject?Body={}&Apikey={}"
   
-  cmdata <- httr::GET(url = url,
-                      query = list(Body = paste0('{"project_cod":"', project, '"}'),
-                                   Apikey = key),
-                      httr::accept_json())
+  cmdata <- httr::RETRY(verb = "GET", 
+                        url = url,
+                        query = list(Body = paste0('{"project_cod":"', project, '"}'),
+                                    Apikey = key),
+                        httr::accept_json(), 
+                        terminate_on = c(403, 404))
   
   cmdata <- httr::content(cmdata, as = "text")
   

--- a/R/getProjectsCM.R
+++ b/R/getProjectsCM.R
@@ -35,9 +35,11 @@ getProjectsCM <- function(key = NULL){
 
   url <- "https://climmob.net/climmob3/api/readProjects?Apikey="
   
-  dat <- httr::GET(url = url, 
-                   query = list(Apikey = key), 
-                   httr::accept_json())
+  dat <- httr::RETRY(verb = "GET",
+                     url = url,
+                     query = list(Apikey = key),
+                     httr::accept_json(),
+                     terminate_on = c(403, 404))
 
   dat <- httr::content(dat, as = "text")
   


### PR DESCRIPTION
Thank you for this awesome project!

In this PR, I'd like to propose swapping out calls to httr::GET() etc. with httr::RETRY(). This will make the package more resilient to transient problems like brief network outages or periods where the service(s) it hits are overwhelmed. In my experience, using retry logic almost always improves the user experience with HTTP clients.

I'm working on chircollab/chircollab20#1 as part of Chicago R Collab, an R 'unconference' in Chicago.